### PR TITLE
Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "prepublish": "npm run build && npm run check"
   },
   "dependencies": {
-    "@apicase/core": "^0.14.5",
+    "@apicase/core": "^0.15.0",
     "delightful-bus": "^0.7.3",
-    "nanoutils": "^0.0.17"
+    "nanoutils": "^0.0.x"
   },
   "devDependencies": {
     "@apicase/adapter-fetch": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepublish": "npm run build && npm run check"
   },
   "dependencies": {
-    "@apicase/core": "^0.15.0",
+    "@apicase/core": "^0.17.0",
     "delightful-bus": "^0.7.3",
     "nanoutils": "^0.0.x"
   },


### PR DESCRIPTION
As seen on the [npm documentation](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004) I believe that the dependency for nanoutils should be updated from `^0.0.17` to `^0.0.x` to make it take the latest version as long as it is <0.1.0.

This would grab some benefits since it will not be needed to update the version of nanoutils every time it release a patch release.

Also updated @apicase/core dependency to 0.15.0